### PR TITLE
Feature: Active Directory, add a Proxy host, Create custom roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Example run command:
          -e LDAP_BIND_PASSWORD=password \ 
          accenture/adop-nexus:VERSION
 
-The image reads the following LDAP environment variables:
+The image reads the following LDAP environment variables for ADOP OpenLDAP or LDAP_TYPE is 'openldap':
 
   * searchBase - `${LDAP_SEARCH_BASE}`
   * systemUsername - `${LDAP_BIND_DN}`
@@ -68,6 +68,17 @@ The image reads the following LDAP environment variables:
   * userBaseDn - `${LDAP_USER_BASE_DN}`
   * userRealNameAttribute - `${LDAP_USER_REAL_NAME_ATTRIBUTE:-cn}`
 
+Additionally, the image reads the following LDAP environment variables if you want to use a Windows Active Directory or LDAP_TYPE is 'active_directory':
+
+  * groupIdAttribute - `${LDAP_GROUP_ID_ATTRIBUTE:-cn}`
+  * groupMemberAttribute - `${LDAP_GROUP_MEMBER_ATTRIBUTE-uniqueMember}`
+  * groupObjectClass - `${LDAP_GROUP_OBJECT_CLASS:-groups}`
+  * userMemberOfAttribute - `${LDAP_USER_MEMBER_ATTRIBUTE:-memberOf}`
+  * userIdAttribute - `${LDAP_USER_ID_ATTRIBUTE:-sAMAccountName}`
+  * userObjectClass - `${LDAP_USER_OBJECT_CLASS:-person}`
+  * userBaseDn - `${LDAP_USER_BASE_DN}`
+  * userRealNameAttribute - `${LDAP_USER_REAL_NAME_ATTRIBUTE:-cn}`
+
 > [Sonatype/Nexus/plugin/LDAP/Documentation](https://books.sonatype.com/nexus-book/reference/ldap.html)
 
 ## Other configuration variables
@@ -77,7 +88,15 @@ The image reads the following LDAP environment variables:
  * `MIN_HEAP`, passed as -Xms. Defaults to 256m.
  * `JAVA_OPTS`. Additional options can be passed to the JVM via this variable. Default: -server -XX:MaxPermSize=192m -Djava.net.preferIPv4Stack=true.
  * `NEXUS_BASE_URL`, the nexus base URL
-
+ * `NEXUS_PROXY_HOST`, the proxy server that connects to Maven public repository. This is used if the Nexus Docker host has strict firewall implementation.
+ * `NEXUS_PROXY_PORT`, the proxy server port.
+ * `NEXUS_CENTRAL_REPO_URL`, if you want to change the Central Repo default maven public repository https://repo1.maven.org/maven2/
+ * `NEXUS_CREATE_CUSTOM_ROLES`, if set to true, create custom roles according to the environment custom role variables:.
+ * `NEXUS_CUSTOM_ADMIN_ROLE` , if set, create a custom group name with nx-admin role.
+ * `NEXUS_CUSTOM_DEV_ROLE` , if set, create a custom group name with nx-developer role.
+ * `NEXUS_CUSTOM_DEPLOY_ROLE`, if set, create a custom group name with nx-deployment role.
+ 
+ 
 # License
 Please view [licence information](LICENCE.md) for the software contained on this image.
 

--- a/resources/nexus.sh
+++ b/resources/nexus.sh
@@ -10,63 +10,143 @@ cp -R /resources/* ${NEXUS_HOME}conf
 
 # Delete lock file if instance was not shutdown cleanly.
 if [ -e "${NEXUS_HOME}/nexus.lock" ] 
-	then
-	echo "$(date) Application was not shutdown cleanly, deleting lock file."
-	rm -rf ${NEXUS_HOME}/nexus.lock
+       then
+       echo "$(date) Application was not shutdown cleanly, deleting lock file."
+       rm -rf ${NEXUS_HOME}/nexus.lock
+fi
+ 
+if [ -n "${NEXUS_BASE_URL}" ]
+       then
+       # Add base url - requests timeout if incorrect
+       sed -i "s#<baseUrl>.*#<baseUrl>${NEXUS_BASE_URL}</baseUrl>#" ${NEXUS_HOME}/conf/nexus.xml
+       echo "$(date) - Base URL: ${NEXUS_BASE_URL}"
 fi
 
-if [ -n "${NEXUS_BASE_URL}" ]
-	then
-	# Add base url - requests timeout if incorrect
-	sed -i "s#<baseUrl>.*#<baseUrl>${NEXUS_BASE_URL}</baseUrl>#" ${NEXUS_HOME}/conf/nexus.xml
-	echo "$(date) Base URL: ${NEXUS_BASE_URL}"
+# Update Remote proxy configuration
+if [[ -n "${NEXUS_PROXY_HOST}" ]] && [[ -n "${NEXUS_PROXY_PORT}" ]]
+    then
+    echo "$(date) - Proxy Host: ${NEXUS_PROXY_HOST}"
+    echo "$(date) - Proxy Port: ${NEXUS_PROXY_PORT}"
+    REMOTE_PROXY_SETTINGS="<remoteProxySettings>\
+    \n    <httpProxySettings>\
+    \n      <proxyHostname>${NEXUS_PROXY_HOST}</proxyHostname>\
+    \n      <proxyPort>${NEXUS_PROXY_PORT}</proxyPort>\
+    \n    </httpProxySettings>\
+    \n  </remoteProxySettings>"
+   sed -i "s+<remoteProxySettings />+${REMOTE_PROXY_SETTINGS}+" ${NEXUS_HOME}/conf/nexus.xml
+fi 
+
+# Update Central Repo configuration
+if [ ! -z "${NEXUS_CENTRAL_REPO_URL}" ]
+        then
+        echo "$(date) - Central Repository URL: ${NEXUS_CENTRAL_REPO_URL}"
+        sed -i "s#https://repo1.maven.org/maven2/#${NEXUS_CENTRAL_REPO_URL}#" ${NEXUS_HOME}/conf/nexus.xml
+fi
+
+# Create a custom Nexus Roles
+if [ ${NEXUS_CREATE_CUSTOM_ROLES} = true ]
+         then
+         echo "$(date) - Administrator role added: ${NEXUS_CUSTOM_ADMIN_ROLE}"
+         echo "$(date) - Developer role added: ${NEXUS_CUSTOM_DEV_ROLE}"
+         echo "$(date) - Deployment role added: ${NEXUS_CUSTOM_DEPLOY_ROLE}"
+         INSERT_ROLE="<roles>\
+         \n    <role>\
+         \n      <id>${NEXUS_CUSTOM_ADMIN_ROLE}</id>\
+         \n      <name>${NEXUS_CUSTOM_ADMIN_ROLE}</name>\
+         \n      <roles>\
+         \n        <role>nx-admin</role>\
+         \n      </roles>\
+         \n    </role>\
+         \n    <role>\
+         \n      <id>${NEXUS_CUSTOM_DEV_ROLE}</id>\
+         \n      <name>${NEXUS_CUSTOM_DEV_ROLE}</name>\
+         \n      <roles>\
+         \n        <role>nx-developer</role>\
+         \n      </roles>\
+         \n    </role>\
+         \n    <role>\
+         \n      <id>${NEXUS_CUSTOM_DEPLOY_ROLE}</id>\
+         \n      <name>${NEXUS_CUSTOM_DEPLOY_ROLE}</name>\
+         \n      <roles>\
+         \n        <role>nx-deployment</role>\
+         \n      </roles>\
+         \n    </role>\
+         \n  </roles>"
+         sed -i "s+</users>+</users>\n  ${INSERT_ROLE}+" ${NEXUS_HOME}/conf/security.xml
 fi
 
 if [ "${LDAP_ENABLED}" = true ]
   then
-
+ 
  # Delete default authentication realms (XMLauth..) from Nexus if LDAP auth is enabled
  # If you get locked out of nexus, restart nexus with LDAP_ENABLED=false.
  sed -i "/[a-zA-Z]*Xml*[a-zA-Z]/d"  ${NEXUS_HOME}/conf/security-configuration.xml
 
-	cat > ${NEXUS_HOME}/conf/ldap.xml <<- EOM  
-		<?xml version="1.0" encoding="UTF-8"?>
-		<ldapConfiguration>
-		  <version>2.8.0</version>
-		  <connectionInfo>
-		    <searchBase>${LDAP_SEARCH_BASE}</searchBase>
-		    <systemUsername>${LDAP_BIND_DN}</systemUsername>
-		    <systemPassword>${LDAP_BIND_PASSWORD}</systemPassword>
-		    <authScheme>simple</authScheme>
-		    <protocol>ldap</protocol>
-		    <host>${LDAP_URL}</host>
-		    <port>${LDAP_PORT:-389}</port>
-		  </connectionInfo>
-		  <userAndGroupConfig>
-		    <emailAddressAttribute>${LDAP_USER_EMAIL_ATTRIBUTE:-mail}</emailAddressAttribute>
-		    <ldapGroupsAsRoles>${LDAP_GROUPS_AS_ROLES:-true}</ldapGroupsAsRoles>
-		    <groupBaseDn>${LDAP_GROUP_BASE_DN}</groupBaseDn>
-		    <groupIdAttribute>${LDAP_GROUP_ID_ATTRIBUTE:-cn}</groupIdAttribute>
-		    <groupMemberAttribute>${LDAP_GROUP_MEMBER_ATTRIBUTE-uniqueMember}</groupMemberAttribute>
-		    <groupMemberFormat>\${${LDAP_GROUP_MEMBER_FORMAT:-dn}}</groupMemberFormat>
-		    <groupObjectClass>${LDAP_GROUP_OBJECT_CLASS:-groupOfUniqueNames}</groupObjectClass>
-		    <preferredPasswordEncoding>${LDAP_PREFERRED_PASSWORD_ENCODING:-crypt}</preferredPasswordEncoding>
-		    <userIdAttribute>${LDAP_USER_ID_ATTRIBUTE:-uid}</userIdAttribute>
-		    <userPasswordAttribute>${LDAP_USER_PASSWORD_ATTRIBUTE:-password}</userPasswordAttribute>
-		    <userObjectClass>${LDAP_USER_OBJECT_CLASS:-inetOrgPerson}</userObjectClass>
-		    <userBaseDn>${LDAP_USER_BASE_DN}</userBaseDn>
-		    <userRealNameAttribute>${LDAP_USER_REAL_NAME_ATTRIBUTE:-cn}</userRealNameAttribute>
-		  </userAndGroupConfig>
-		</ldapConfiguration>
-	EOM
-else
-	# Delete LDAP realm
-	sed -i "/[a-zA-Z]*Ldap*[a-zA-Z]/d" ${NEXUS_HOME}/conf/security-configuration.xml
-fi
+# Define the correct LDAP user and group mapping configurations
+  LDAP_TYPE=${LDAP_TYPE:-openldap}
+  echo "$(date) - LDAP Type: ${LDAP_TYPE}"
+ 
+  case $LDAP_TYPE in
+  'openldap')
+   LDAP_USER_GROUP_CONFIG="  <userAndGroupConfig>
+        <emailAddressAttribute>${LDAP_USER_EMAIL_ATTRIBUTE:-mail}</emailAddressAttribute>
+        <ldapGroupsAsRoles>${LDAP_GROUPS_AS_ROLES:-true}</ldapGroupsAsRoles>
+        <groupBaseDn>${LDAP_GROUP_BASE_DN}</groupBaseDn>
+        <groupIdAttribute>${LDAP_GROUP_ID_ATTRIBUTE:-cn}</groupIdAttribute>
+        <groupMemberAttribute>${LDAP_GROUP_MEMBER_ATTRIBUTE-uniqueMember}</groupMemberAttribute>
+        <groupMemberFormat>\${${LDAP_GROUP_MEMBER_FORMAT:-dn}}</groupMemberFormat>
+        <groupObjectClass>${LDAP_GROUP_OBJECT_CLASS:-groupOfUniqueNames}</groupObjectClass>
+        <preferredPasswordEncoding>${LDAP_PREFERRED_PASSWORD_ENCODING:-crypt}</preferredPasswordEncoding>
+        <userIdAttribute>${LDAP_USER_ID_ATTRIBUTE:-uid}</userIdAttribute>
+        <userPasswordAttribute>${LDAP_USER_PASSWORD_ATTRIBUTE:-password}</userPasswordAttribute>
+        <userObjectClass>${LDAP_USER_OBJECT_CLASS:-inetOrgPerson}</userObjectClass>
+        <userBaseDn>${LDAP_USER_BASE_DN}</userBaseDn>
+        <userRealNameAttribute>${LDAP_USER_REAL_NAME_ATTRIBUTE:-cn}</userRealNameAttribute>
+      </userAndGroupConfig>"
+  ;;
 
+  'active_directory')
+   LDAP_USER_GROUP_CONFIG="  <userAndGroupConfig>
+        <emailAddressAttribute>mail</emailAddressAttribute>
+        <ldapGroupsAsRoles>${LDAP_GROUPS_AS_ROLES:-true}</ldapGroupsAsRoles>
+        <groupIdAttribute>${LDAP_GROUP_ID_ATTRIBUTE:-cn}</groupIdAttribute>
+        <groupMemberAttribute>${LDAP_GROUP_MEMBER_ATTRIBUTE-uniqueMember}</groupMemberAttribute>
+        <groupMemberFormat>\${${LDAP_GROUP_MEMBER_FORMAT:-dn}}</groupMemberFormat>
+        <groupObjectClass>${LDAP_GROUP_OBJECT_CLASS:-groups}</groupObjectClass>
+        <userIdAttribute>${LDAP_USER_ID_ATTRIBUTE:-sAMAccountName}</userIdAttribute>
+        <userObjectClass>${LDAP_USER_OBJECT_CLASS:-person}</userObjectClass>
+        <userBaseDn>${LDAP_USER_BASE_DN}</userBaseDn>
+        <userRealNameAttribute>${LDAP_USER_REAL_NAME_ATTRIBUTE:-cn}</userRealNameAttribute>
+        <userMemberOfAttribute>${LDAP_USER_MEMBER_ATTRIBUTE:-memberOf}</userMemberOfAttribute>
+      </userAndGroupConfig>"
+   ;;
+  esac
+ 
+cat > ${NEXUS_HOME}/conf/ldap.xml <<- EOM
+<?xml version="1.0" encoding="UTF-8"?>
+<ldapConfiguration>
+  <version>2.8.0</version>
+  <connectionInfo>
+    <searchBase>${LDAP_SEARCH_BASE}</searchBase>
+    <systemUsername>${LDAP_BIND_DN}</systemUsername>
+    <systemPassword>${LDAP_BIND_PASSWORD}</systemPassword>
+    <authScheme>simple</authScheme>
+    <protocol>ldap</protocol>
+    <host>${LDAP_URL}</host>
+    <port>${LDAP_PORT:-389}</port>
+  </connectionInfo>
+${LDAP_USER_GROUP_CONFIG}
+</ldapConfiguration>
+EOM
+
+else
+    # Delete LDAP realm
+    sed -i "/[a-zA-Z]*Ldap*[a-zA-Z]/d" ${NEXUS_HOME}/conf/security-configuration.xml
+fi
+ 
 # chown the nexus home directory
 chown -R nexus:nexus ${NEXUS_HOME}
-
+ 
 # start nexus as the nexus user
 su -c "java \
 -Dnexus-work=${SONATYPE_WORK} -Dnexus-webapp-context-path=${CONTEXT_PATH} \


### PR DESCRIPTION
@nickdgriffin,

These are extensions that we made in ADOP Nexus from one of our projects. All of the changes are done in nexus.sh.

- The ability to create custom group name for nx-admin, nx-developers and nx-deployment
- The ability to add a proxy host and proxy port when your Nexus VM has no direct connectivity to Maven repo due to on-premise strict firewall implementation.
- The ability to choose LDAP_TYPE between ADOP 'openldap' and 'active_directory'.

@WYarde please follow this request.These are the customization from our project MOHH. Thanks!
