### PR TITLE
Modifying configuration in ldap.xml to support on-premise ldap

### DIFF
--- a/resources/nexus.sh
+++ b/resources/nexus.sh
@@ -105,10 +105,12 @@ if [ "${LDAP_ENABLED}" = true ]
         <groupObjectClass>${LDAP_GROUP_OBJECT_CLASS:-groupOfUniqueNames}</groupObjectClass>
         <preferredPasswordEncoding>${LDAP_PREFERRED_PASSWORD_ENCODING:-crypt}</preferredPasswordEncoding>
         <userIdAttribute>${LDAP_USER_ID_ATTRIBUTE:-uid}</userIdAttribute>
-        <userPasswordAttribute>${LDAP_USER_PASSWORD_ATTRIBUTE:-password}</userPasswordAttribute>
+        <userPasswordAttribute>${LDAP_USER_PASSWORD_ATTRIBUTE-password}</userPasswordAttribute>
         <userObjectClass>${LDAP_USER_OBJECT_CLASS:-inetOrgPerson}</userObjectClass>
         <userBaseDn>${LDAP_USER_BASE_DN}</userBaseDn>
         <userRealNameAttribute>${LDAP_USER_REAL_NAME_ATTRIBUTE:-cn}</userRealNameAttribute>
+        <userSubtree>${LDAP_USER_SUBTREE:-false}</userSubtree>
+        <groupSubtree>${LDAP_GROUP_SUBTREE:-false}</groupSubtree>
       </userAndGroupConfig>"
   ;;
 


### PR DESCRIPTION
Two changes have been made to ldap.xml.

These lines have been added:
```
<userSubtree>${LDAP_USER_SUBTREE:-false}</userSubtree>
<groupSubtree>${LDAP_GROUP_SUBTREE:-false}</groupSubtree>
```

The userSubtree and groupSubtree were already set to false in ADOP. However, on some projects ldap can be set up to utilise them. With this change the two parameters can be defined to be true from the docker-compose.yml file in ADOP. 

The second change is: 
```
<userPasswordAttribute>${LDAP_USER_PASSWORD_ATTRIBUTE-password}</userPasswordAttribute>
```

The previous syntax ${parameter:-value} was modified to ${parameter-value}. In our set up we do not define LDAP_USER_PASSWORD_ATTRIBUTE and this change is needed in order not to be set to the default value which is password. 

The change has been tested and working as expected. 