### PR TITLE
Adding custom stdout logging strategy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Robert Northard, <robert.a.northard>
 ENV LDAP_ENABLED=true \
     CONTEXT_PATH=/nexus \
     NEXUS_HOME=/sonatype-work/ \
+    DEBUG_LOGGING=false \
     LDAP_SEARCH_BASE="" \
     LDAP_URL="" \
     LDAP_PORT=389 \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Supported tags and respective Dockerfile links
 
-- [`0.1.0`, `0.1.0` (*0.1.0/Dockerfile*)](https://github.com/Accenture/adop-nexus/blob/master/Dockerfile.md)
+- [`0.1.3`, `0.1.3` (*0.1.0/Dockerfile*)](https://github.com/Accenture/adop-nexus/blob/master/Dockerfile.md)
 
 # What is adop-nexus?
 adop-nexus is a wrapper for the sonatype/nexus image. It has primarily been built to perform extended configuration. Nexus® is an artifact repository manager.
@@ -15,14 +15,14 @@ To start the server, where version is the release version of the Docker containe
     
       $ docker run -d --name nexus -p 8081:8081 -e LDAP_ENABLED=false accenture/adop-nexus:VERSION
 
-If LDAP authentication is disabled the default user/password is:
+If LDAP authentication is disabled, the default user/password is:
   
   * username: `admin`
   * password: `admin123`
 
 ## Persisting data
 
-To persis data mount out the /sonatype-work directory.
+To persist data mount out the /sonatype-work directory.
 
 e.g. $ docker run -d --name nexus -v $(pwd)/data:/sonatype-work -p 8081:8081 -e LDAP_ENABLED=false accenture/adop-nexus:VERSION
 
@@ -84,6 +84,7 @@ Additionally, the image reads the following LDAP environment variables if you wa
 ## Other configuration variables
 
  * `CONTEXT_PATH`, passed as -Dnexus-webapp-context-path. This is used to define the URL which Nexus is accessed.
+ * `DEBUG_LOGGING`, defaults to false. If this is set to true, additional debug/access logs are enabled and sent to stdout/specified logging driver.
  * `MAX_HEAP`, passed as -Xmx. Defaults to 1g.
  * `MIN_HEAP`, passed as -Xms. Defaults to 256m.
  * `JAVA_OPTS`. Additional options can be passed to the JVM via this variable. Default: -server -XX:MaxPermSize=192m -Djava.net.preferIPv4Stack=true.

--- a/resources/conf/logback/logback-access.xml
+++ b/resources/conf/logback/logback-access.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+
+    Sonatype Nexus (TM) Open Source Version
+    Copyright (c) 2008-2015 Sonatype, Inc.
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+    which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+    Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+    of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+    Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
+<configuration>
+
+  <!-- always a good activate OnConsoleStatusListener -->
+  <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{yyyy-MM-dd HH:mm:ss} REQUEST %h %l %u %user "%r" %s %b</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="request.logfile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <File>${nexus-work}/logs/request.log</File>
+    <Append>true</Append>
+    <encoder class="org.sonatype.nexus.bootstrap.log.AccessPatternLayoutEncoder">
+      <pattern>common</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${nexus-work}/logs/request.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+      <maxHistory>90</maxHistory>
+    </rollingPolicy>
+  </appender>
+
+  <appender-ref ref="STDOUT" />
+  <appender-ref ref="request.logfile"/>
+</configuration>

--- a/resources/conf/logback/logback-nexus.xml
+++ b/resources/conf/logback/logback-nexus.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Sonatype Nexus (TM) Open Source Version
+    Copyright (c) 2008-2015 Sonatype, Inc.
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+    which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+    Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+    of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+    Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
+<included>
+  <jmxConfigurator/>
+
+  <logger name="org.apache.shiro.realm.AuthenticatingRealm" level="DEBUG" />
+
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${appender.pattern}</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="logfile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <File>${appender.file}</File>
+    <Append>true</Append>
+    <encoder>
+      <pattern>${appender.pattern}</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${appender.file}.%d{yyyy-MM-dd}.gz</fileNamePattern>
+      <maxHistory>90</maxHistory>
+    </rollingPolicy>
+  </appender>
+
+  <appender name="metrics" class="com.yammer.metrics.logback.InstrumentedAppender"/>
+
+  <root level="${root.level}">
+    <appender-ref ref="console"/>
+    <appender-ref ref="logfile"/>
+    <appender-ref ref="metrics"/>
+  </root>
+
+</included>

--- a/resources/conf/logback/logback.properties
+++ b/resources/conf/logback/logback.properties
@@ -1,0 +1,17 @@
+#
+# Sonatype Nexus (TM) Open Source Version
+# Copyright (c) 2008-2015 Sonatype, Inc.
+# All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+#
+# This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+# which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+#
+# Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+# of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+# Eclipse Foundation. All other trademarks are the property of their respective owners.
+#
+
+root.level=INFO
+
+appender.pattern=%4d{yyyy-MM-dd HH:mm:ss} %-5p [%thread] %X{userId} %c - %m%n
+appender.file=${nexus-work}/logs/nexus.log

--- a/resources/nexus.sh
+++ b/resources/nexus.sh
@@ -13,6 +13,13 @@ mkdir -p ${NEXUS_HOME}conf
 cp -R /resources/conf/managed/* ${NEXUS_HOME}conf
 cp -R -n /resources/conf/unmanaged/* ${NEXUS_HOME}conf
 
+# Copy in custom logback configuration which prints application and access logs to stdout if environment variable is set to true
+cp /resources/conf/logback/logback.properties ${NEXUS_HOME}conf
+if [[ ${DEBUG_LOGGING} == true ]]
+  then
+  cp /resources/conf/logback/logback-nexus.xml ${NEXUS_HOME}conf
+  cp /resources/conf/logback/logback-access.xml /opt/sonatype/nexus/conf/
+fi
 
 # Delete lock file if instance was not shutdown cleanly.
 if [ -e "${NEXUS_HOME}/nexus.lock" ] 


### PR DESCRIPTION
The nexus access logs are currently appended to a static file. This PR configures the logback XML configuration to output the access HTTP requests to the "Console" logger using existing libraries. Hence now when you run "docker logs nexus" you can see the access requests made to nexus. This is enabled by setting an environment variable to true. As an example:
```
2016-10-21 16:22:21 REQUEST 172.18.0.19 - - - "GET /nexus/ HTTP/1.1" 200 8009

```