### PR TITLE
Preventing recursive chown on container restarts

### DIFF
--- a/resources/nexus.sh
+++ b/resources/nexus.sh
@@ -162,8 +162,10 @@ else
     sed -i "/LdapAuthenticatingRealm/d" ${NEXUS_HOME}/conf/security-configuration.xml
 fi
  
-# chown the nexus home directory
-chown -R nexus:nexus ${NEXUS_HOME}
+# chown the nexus home directory if running for the first time
+if [[ $(ls -ld ${NEXUS_HOME}storage | awk '{print $3}') != nexus ]]; then
+  chown -R nexus:nexus ${NEXUS_HOME}
+fi
  
 # start nexus as the nexus user
 su -c "java \


### PR DESCRIPTION
This PR is to wrap the recursive chown command in a conditional if statement.

This is to counter the scenario where you remove your container but leave your docker volume. In the case where the volume has a siginificant amount of data in it, restarting the container will trigger the recursive chown command via the entrypoint script. This causes Nexus to be non-functional for an hour or so if the data size is ~30GB as it chowns through all the files.

This PR protects against this scenario as it will check the top level directory owner and if it is nexus it will skip the chown.