### PR TITLE
Updating intermediate docker image in Dockerfile to 2.14.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonatype/nexus:2.11.2-06
+FROM sonatype/nexus:2.14.5
 
 MAINTAINER Robert Northard, <robert.a.northard>
 

--- a/resources/nexus.sh
+++ b/resources/nexus.sh
@@ -166,7 +166,7 @@ fi
 chown -R nexus:nexus ${NEXUS_HOME}
  
 # start nexus as the nexus user
-su -c "java \
+su -c "${JAVA_HOME}/bin/java \
 -Dnexus-work=${SONATYPE_WORK} -Dnexus-webapp-context-path=${CONTEXT_PATH} \
 -Xms${MIN_HEAP} -Xmx${MAX_HEAP} \
 -cp 'conf/:lib/*' \

--- a/resources/nexus.sh
+++ b/resources/nexus.sh
@@ -163,7 +163,8 @@ else
 fi
  
 # chown the nexus home directory
-chown -R nexus:nexus ${NEXUS_HOME}
+chown nexus:nexus "${NEXUS_HOME}"
+chown -R nexus:nexus $(ls ${NEXUS_HOME} | awk -v NEXUS_HOME="${NEXUS_HOME}/" '{if($1 != "storage"){ print NEXUS_HOME$1 }}')
  
 # start nexus as the nexus user
 su -c "${JAVA_HOME}/bin/java \


### PR DESCRIPTION
Changes:
* Updated the intermediate image in Dockerfile from 2.11.2-06 to 2.14.5 that is needed to be able to upgrade to Nexus 3.6.2
* Updated the java path in nexus.sh to match the java path in 2.14.5 dockerfile: https://github.com/sonatype/docker-nexus/blob/2.14.5/oss/Dockerfile
* Updated chown commands to prevent recursive chown on container restarts

The changes has been tested and working as expected.
  