### PR TITLE
Increasing Version to 3.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonatype/nexus3:3.7.1
+FROM sonatype/nexus3:3.12.1
 
 
 ENV LDAP_ENABLED=true \

--- a/resources/conf/addUpdatescript.groovy
+++ b/resources/conf/addUpdatescript.groovy
@@ -24,7 +24,7 @@ def file = new File(options.f)
 assert file.exists()
 
 def host = options.h ?: 'http://localhost:8081'
-def resource = 'service/siesta'
+def resource = 'service/'
 
 ScriptClient scripts = new ResteasyClientBuilder()
     .build()

--- a/resources/provision.sh
+++ b/resources/provision.sh
@@ -39,7 +39,7 @@ function addAndRunScript() {
   classPath=$(find /root/.groovy/grapes -name *.jar)
   groovy -cp $(echo $classPath | sed 's/ /:/g') -Dgroovy.grape.report.downloads=true resources/conf/addUpdatescript.groovy -u "$username" -p "$password" -n "$name" -f "$file" -h "$nexus_host"
   printf "\nPublished $file as $name\n\n"
-  curl -v -X POST -u $username:$password --header "Content-Type: text/plain" "$nexus_host/service/siesta/rest/v1/script/$name/run" -d "$args"
+  curl -v -X POST -u $username:$password --header "Content-Type: text/plain" "$nexus_host/service/rest/v1/script/$name/run" -d "$args"
   printf "\nSuccessfully executed $name script\n\n\n"
 }
 


### PR DESCRIPTION
When installing version 3.7.1-02 the following messaging is displayed at the head of the Dashboard:
![image](https://user-images.githubusercontent.com/37773304/42034366-b84bc5ea-7ad7-11e8-97a3-d23c02fb566b.png)

Increasing version to 3.12.1; as part of the 3.8.0 release /siesta has been deprecated (NEXUS-14940). Therefore the additional scripts which execute under the provision script were affected. I have amended this slightly to correct the API call. 

I've tested that the scripts are still able to successfully execute and configure components like LDAP etc. 

Thank you, Lee